### PR TITLE
Automated docker image builds (#323)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+*.yaml
+*.md
+docs
+Dockerfile
+scripts
+tests
+venv

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,55 @@
+name: Docker image
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get the release channel
+        id: get_channel
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == 'refs/heads/main' ]]; then
+            echo ::set-output name=channel::"latest"
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/heads/"* ]]; then
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+            echo ::set-output name=channel::${GITHUB_REF/refs\/tags\//}
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.get_channel.outputs.channel }}
+            type=raw,value=${{ steps.get_channel.outputs.version }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+ENV CHIADOG_CONFIG_DIR=/root/.chiadog/config.yaml
+ENV TZ=UTC
+
+COPY . /chiadog
+WORKDIR /chiadog
+RUN python3 -m venv venv \
+&& . ./venv/bin/activate \
+&& pip3 install -r requirements.txt
+
+ENTRYPOINT ["/chiadog/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /chiadog
+. ./venv/bin/activate
+python main.py --config ${CHIADOG_CONFIG_DIR}


### PR DESCRIPTION
* Inhouse Dockerfile and entrypoint from ajacobson/chiadog-docker

This brings over only only drop dead simple bits that really should live
with the tool itself.

Major benefits:
- Can easily build any state of the repo regardless of branch or
  mid-development into a functional image without mucking about with an
  external repo.
- Faster builds when the source code is already present without an extra
  clone

Minor fixes added as well:
- entrypoint.sh was missing a shebang
- Simplified entrypoint running now that the script has a proper
  shabang
- Simplified logic by switching WORKDIR earlier
- Add a .dockerignore file to prune dirty state and useless weight from
  the container.

Does not include:
- Any documentation. Docker is an advanced option in any case but this
  should be added as a followup.
- Automated Docker builds. Those come in the next commit.

* Automate building of Docker images.

- Images based on the `main` branch will update the `latest` tag.
- Other branches will be tagged with the branch name and first 6 chars
  of commit hash.
- Any git tags will tag images as-is, say `v0.7.0` would become: `ghcr.io/martomi/chiadog:v0.7.0`

* Simplify & improve Docker image, change config env to CHIADOG_CONFIG_DIR

- Breaking change for anyone coming from ajacobson/chiadog-docker: The
  config dir env variable is now called CHIADOG_CONFIG_DIR
- Switch base image to python:3.10-slim, reduced image size
  significantly
- Dropped manual TZ handling at the container system level, just setting
  env TZ is enough
- Dropped manual PyNaCL install, requirements pull in the binary wheel
  just fine
- Simplify entrypoint and use sh for security.